### PR TITLE
Correction hierarchies des titres

### DIFF
--- a/src/components/Error.jsx
+++ b/src/components/Error.jsx
@@ -8,7 +8,7 @@ export default function Error() {
   return (
     <main>
       <section className="error">
-        <h1 className="error__title">404</h1>
+        <h2 className="error__title">404</h2>
         <p className="error__message">
           Oups! La page que vous demandez n'existe pas.
         </p>


### PR DESCRIPTION
- Changement de titre h1 "404" en h2 pour une meilleure hierarchies des titres.